### PR TITLE
Efficiency Increase

### DIFF
--- a/python/eulerlib.py
+++ b/python/eulerlib.py
@@ -34,9 +34,10 @@ def is_prime(x):
 	elif x % 2 == 0:
 		return False
 	else:
-		for i in range(3, sqrt(x) + 1, 2):
-			if x % i == 0:
-				return False
+		for i in range(6, sqrt(x) + 1, 6):
+			for j in (i - 1, i + 1):
+				if x % i == 0:
+					return False
 		return True
 
 


### PR DESCRIPTION
All primes other than 2 or 3 have to be directly adjacent to a multiple of 6, since all other numbers are a multiple of 2, 3 or both. My solution provides a slight performance increase due to the fact that it checks 33% fewer numbers.